### PR TITLE
Renaming of modules

### DIFF
--- a/assembly/kar/pom.xml
+++ b/assembly/kar/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <groupId>org.opennms</groupId>
+        <groupId>org.opennms.plugins.velocloud</groupId>
         <artifactId>assembly</artifactId>
         <version>0.1.0-SNAPSHOT</version>
     </parent>
@@ -24,7 +24,7 @@
                             <goal>kar</goal>
                         </goals>
                         <configuration>
-                            <featuresFile>mvn:org.opennms/karaf-features/${project.version}/xml</featuresFile>
+                            <featuresFile>mvn:org.opennms.plugins.velocloud/karaf-features/${project.version}/xml</featuresFile>
                             <finalName>opennms-velocloud-plugin</finalName>
                             <ignoreDependencyFlag>true</ignoreDependencyFlag>
                             <archive>
@@ -41,7 +41,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.opennms</groupId>
+            <groupId>org.opennms.plugins.velocloud</groupId>
             <artifactId>karaf-features</artifactId>
             <version>${project.version}</version>
             <type>xml</type>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -1,27 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-      
   <parent>
-            
-    <groupId>org.opennms</groupId>
-            
-    <artifactId>velocloud-integration</artifactId>
-            
+    <groupId>org.opennms.plugins.velocloud</groupId>
+    <artifactId>velocloud-plugin-parent</artifactId>
     <version>0.1.0-SNAPSHOT</version>
-        
   </parent>
-      
   <modelVersion>4.0.0</modelVersion>
-      
   <artifactId>assembly</artifactId>
-      
   <name>OpenNMS :: Plugins :: Velocloud Intergration :: Assembly</name>
-      
   <packaging>pom</packaging>
   
   <modules>
-      
     <module>kar</module>
-      
   </modules>
 </project>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -3,8 +3,8 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>velocloud-integration</artifactId>
-        <groupId>org.opennms</groupId>
+        <groupId>org.opennms.plugins.velocloud</groupId>
+        <artifactId>velocloud-plugin-parent</artifactId>
         <version>0.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/karaf-features/pom.xml
+++ b/karaf-features/pom.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <groupId>org.opennms</groupId>
-        <artifactId>velocloud-integration</artifactId>
+        <groupId>org.opennms.plugins.velocloud</groupId>
+        <artifactId>velocloud-plugin-parent</artifactId>
         <version>0.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -84,8 +84,9 @@
                             </framework>
                             <features>
                                 <feature>opennms-plugins-velocloud</feature>
-                                <feature>client</feature>
+                                <feature>opennms-plugins-velocloud-client</feature>
                                 <feature>guava</feature>
+                                <feature>jackson</feature>
                             </features>
                         </configuration>
                     </execution>
@@ -112,13 +113,13 @@
         </dependency>
 
         <dependency>
-            <groupId>org.opennms</groupId>
+            <groupId>org.opennms.plugins.velocloud</groupId>
             <artifactId>velocloud-plugin</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.opennms</groupId>
+            <groupId>org.opennms.plugins.velocloud</groupId>
             <artifactId>velocloud-client</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/karaf-features/src/main/resources/features.xml
+++ b/karaf-features/src/main/resources/features.xml
@@ -6,11 +6,11 @@
         <feature dependency="true">shell</feature>
         <feature version="${opennms.api.version}" dependency="true">opennms-integration-api</feature>
         <feature version="${guava.version}" dependency="true">guava</feature>
-        <feature version="${project.version}">client</feature>
+        <feature version="${project.version}">opennms-plugins-velocloud-client</feature>
         <bundle dependency="true">mvn:org.apache.commons/commons-jexl3/${jexl.version}</bundle>
         <bundle dependency="true">mvn:io.dropwizard.metrics/metrics-core/${metrics.version}</bundle>
         <bundle dependency="true">mvn:javax.ws.rs/javax.ws.rs-api/2.1.1</bundle>
-        <bundle>mvn:org.opennms/velocloud-plugin/${project.version}</bundle>
+        <bundle>mvn:org.opennms.plugins.velocloud/velocloud-plugin/${project.version}</bundle>
     </feature>
 
     <feature name="guava" description="guava" version="${guava.version}">
@@ -26,7 +26,7 @@
         <bundle dependency="true">mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/${jackson.version}</bundle>
     </feature>
 
-    <feature name="client" description="Velocloud API client" version="${project.version}">
+    <feature name="opennms-plugins-velocloud-client" description="Velocloud API client" version="${project.version}">
         <feature version="${jackson.version}" dependency="true">jackson</feature>
         <bundle dependency="true">mvn:io.swagger.core.v3/swagger-annotations/${swagger.version}</bundle>
 
@@ -42,7 +42,6 @@
         <bundle dependency="true">mvn:org.jvnet.mimepull/mimepull/1.10.0</bundle>
         <bundle dependency="true">mvn:javax.annotation/javax.annotation-api/1.3.2</bundle>
         
-
-        <bundle>mvn:org.opennms/velocloud-client/${project.version}</bundle>
+        <bundle>mvn:org.opennms.plugins.velocloud/velocloud-client/${project.version}</bundle>
     </feature>
 </features>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <groupId>org.opennms</groupId>
-        <artifactId>velocloud-integration</artifactId>
+        <groupId>org.opennms.plugins.velocloud</groupId>
+        <artifactId>velocloud-plugin-parent</artifactId>
         <version>0.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>velocloud-integration</artifactId>
-    <groupId>org.opennms</groupId>
+    <artifactId>velocloud-plugin-parent</artifactId>
+    <groupId>org.opennms.plugins.velocloud</groupId>
     <name>OpenNMS :: Plugins :: Velocloud Intergration :: Parent</name>
     <packaging>pom</packaging>
 


### PR DESCRIPTION
This renames modules from `org.opennms` to `org.opennms.plugins.velocould` to avoid any conflicts with existing ONMS modules.