### PR TITLE
Added some Edge Entities to map Velocloud Edge/Links

### DIFF
--- a/plugin/src/main/java/org/opennms/velocloud/model/EdgeIpInterface.java
+++ b/plugin/src/main/java/org/opennms/velocloud/model/EdgeIpInterface.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.velocloud.model;
+
+import org.opennms.integration.api.v1.model.IpInterface;
+import org.opennms.integration.api.v1.model.MetaData;
+import org.opennms.integration.api.v1.model.SnmpInterface;
+import org.opennms.integration.api.xml.schema.eventconf.Snmp;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class EdgeIpInterface implements IpInterface {
+
+    private InetAddress ipAddress;
+    private Optional<SnmpInterface> snmpInterface;
+    private final List<MetaData> metaData = new ArrayList<>();
+
+    public EdgeIpInterface(final String ipAddress){
+        try {
+            this.ipAddress = InetAddress.getByName(ipAddress);
+        } catch (UnknownHostException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public InetAddress getIpAddress() {
+        return ipAddress;
+    }
+
+    @Override
+    public Optional<SnmpInterface> getSnmpInterface() {
+        return snmpInterface;
+    }
+
+    @Override
+    public List<MetaData> getMetaData() {
+        return metaData;
+    }
+}

--- a/plugin/src/main/java/org/opennms/velocloud/model/EdgeMetaData.java
+++ b/plugin/src/main/java/org/opennms/velocloud/model/EdgeMetaData.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.velocloud.model;
+
+import org.opennms.integration.api.v1.model.MetaData;
+
+public class EdgeMetaData implements MetaData {
+
+    private final String context = "_Velocloud_";
+    private final String key;
+    private final String value;
+
+    public EdgeMetaData(final String key, final String value){
+        this.key = key;
+        this.value = value;
+    }
+
+    @Override
+    public String getContext() {
+        return null;
+    }
+
+    @Override
+    public String getKey() {
+        return null;
+    }
+
+    @Override
+    public String getValue() {
+        return null;
+    }
+}

--- a/plugin/src/main/java/org/opennms/velocloud/model/EdgeNode.java
+++ b/plugin/src/main/java/org/opennms/velocloud/model/EdgeNode.java
@@ -1,0 +1,145 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.velocloud.model;
+
+import org.opennms.integration.api.v1.model.IpInterface;
+import org.opennms.integration.api.v1.model.MetaData;
+import org.opennms.integration.api.v1.model.Node;
+import org.opennms.integration.api.v1.model.NodeAssetRecord;
+import org.opennms.integration.api.v1.model.SnmpInterface;
+
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class EdgeNode implements Node {
+
+
+    private final List<MetaData> metaData = new ArrayList<>();
+    private final List<SnmpInterface> snmpInterfaces = new ArrayList<>();
+    private final List<String> categories = new ArrayList<>();
+    private final List<IpInterface> ipInterfaces = new ArrayList<>();
+
+    private NodeAssetRecord nodeAssetRecord;
+    private Integer nodeId;
+    private String foreignSource;
+    private String foreignId;
+    private String label;
+    private String location;
+    private String linkStatus;
+
+
+    public EdgeNode(){
+
+    }
+
+    @Override
+    public Integer getId() {
+        return nodeId;
+    }
+
+    @Override
+    public String getForeignSource() {
+        return foreignSource;
+    }
+
+    @Override
+    public String getForeignId() {
+        return foreignId;
+    }
+
+    @Override
+    public String getLabel() {
+        return label;
+    }
+
+    @Override
+    public String getLocation() {
+        return location;
+    }
+
+    @Override
+    public NodeAssetRecord getAssetRecord() {
+        return nodeAssetRecord;
+    }
+
+    @Override
+    public List<IpInterface> getIpInterfaces() {
+        return ipInterfaces;
+    }
+
+    @Override
+    public Optional<IpInterface> getInterfaceByIp(InetAddress ipAddr) {
+        return ipInterfaces.stream().filter(i->i.getIpAddress().equals(ipAddr)).findFirst();
+    }
+
+    @Override
+    public List<SnmpInterface> getSnmpInterfaces() {
+        return snmpInterfaces;
+    }
+
+    @Override
+    public List<MetaData> getMetaData() {
+        return metaData;
+    }
+
+    @Override
+    public List<String> getCategories() {
+        return categories;
+    }
+
+    public void setNodeAssetRecord(org.opennms.integration.api.v1.model.NodeAssetRecord nodeAssetRecord) {
+        this.nodeAssetRecord = nodeAssetRecord;
+    }
+
+    public void setNodeId(Integer nodeId) {
+        this.nodeId = nodeId;
+    }
+
+    public void setForeignSource(String foreignSource) {
+        this.foreignSource = foreignSource;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+    public void setLinkStatus(String linkStatus){
+        this.linkStatus = linkStatus;
+    }
+
+
+}
+
+

--- a/plugin/src/main/java/org/opennms/velocloud/requisition/CustomerRequisitionProvider.java
+++ b/plugin/src/main/java/org/opennms/velocloud/requisition/CustomerRequisitionProvider.java
@@ -28,16 +28,28 @@
 
 package org.opennms.velocloud.requisition;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
 import org.opennms.integration.api.v1.config.requisition.Requisition;
 import org.opennms.integration.api.v1.config.requisition.immutables.ImmutableRequisition;
+import org.opennms.integration.api.v1.dao.NodeDao;
+import org.opennms.integration.api.v1.model.IpInterface;
+import org.opennms.integration.api.v1.model.Node;
 import org.opennms.velocloud.client.VelocloudApiClient;
+import org.opennms.velocloud.client.handler.ApiException;
+import org.opennms.velocloud.client.model.EdgeResourceCollection;
+import org.opennms.velocloud.model.EdgeIpInterface;
+import org.opennms.velocloud.model.EdgeMetaData;
+import org.opennms.velocloud.model.EdgeNode;
 
 public class CustomerRequisitionProvider extends AbstractRequisitionProvider<CustomerRequisitionProvider.Request> {
 
     public final static String TYPE = "VelocloudCustomerRequisition";
+    private final List<IpInterface> ipInterfaces = new ArrayList<>();
+    private final List<Node> nodes = new ArrayList<>();
 
     @Override
     public String getType() {
@@ -58,9 +70,52 @@ public class CustomerRequisitionProvider extends AbstractRequisitionProvider<Cus
     @Override
     protected Requisition handleRequest(final Request request, final VelocloudApiClient client) {
         final var requisition = ImmutableRequisition.newBuilder()
-                                                    .setForeignSource(request.getForeignSource());
+                .setForeignSource(request.getForeignSource());
+
+
+        try {
+            var enterpriseEdges = client.edges.getEnterpriseEdges(request.enterpriseId.toString(),
+                    null, null, null, null, null, null, null, null, null, null,
+                    null, null, null, null, null, null, null, null, null, null,
+                    null, null, null, null, null, null, null, null, null, null,
+                    null, null, null, null, null, null, null, null, null, null,
+                    null, null, null, null, null, null, null, null, null, null,
+            null, null, null, null, null, null, null, null, null, null,
+                    null, null, null, null, null, null, null, null, null, null,
+                    null, null, null, null, null, null, null, null, null, null,
+                    null, null, null, null, null, null, null, null, null);
+        List<EdgeNode> nodes = getEdgeNodes(enterpriseEdges);
+        //TODO find how to fetch link info since it not available from edges (just an _href)
+
+        } catch (ApiException e) {
+            e.printStackTrace();
+        }
 
         return requisition.build();
+    }
+
+    private List<EdgeNode> getEdgeNodes(EdgeResourceCollection enterpriseEdges) {
+        ArrayList<EdgeNode> edgeNodes = new ArrayList<EdgeNode>();
+
+        enterpriseEdges.getData().stream().forEach(resource->{
+            //Edge is interpreted as a node
+            EdgeNode edgeNode = new EdgeNode();
+            //Edge link (link between edge and gateway)
+            //Edge can have many links
+            var links = resource.getLinks();
+            //TODO map links to a resources and generate ipInterfaces NMS-14596
+            //edgeNode.getIpInterfaces().add(new EdgeIpInterface(""){});
+
+            //TODO map link Status NMS-14596
+
+            edgeNode.setLabel(resource.getName());
+            //capture all 3 identifiers for each Velocloud Edge as OpenNMS Node meta-data
+            edgeNode.getMetaData().add(new EdgeMetaData("deviceId", resource.getDeviceId()));
+            edgeNode.getMetaData().add(new EdgeMetaData("logicalId", resource.getLogicalId()));
+            edgeNode.getMetaData().add(new EdgeMetaData("selfMacAddress", resource.getSelfMacAddress()));
+
+        });
+        return edgeNodes;
     }
 
     public static class Request extends AbstractRequisitionProvider.Request {


### PR DESCRIPTION
Added some ONMS entities to map Velocloud Edges/Links data.
SDWAN API v2 seems that it doesn't provide the same info as the v1 and information related to gateways or links is not enough to complete this mapping (AFAIK) I might be wrong so I'm following up with the vmware comunity forum.

Still work in progress