### PR TITLE
DP-96: Add meta descriptions to each page in the Velocloud docs

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,8 @@
 name: velocloud
 version: '2.0.0-SNAPSHOT'
 title: Velocloud Plugin
+asciidoc:
+  attributes:
+    full-display-version: '2.0.0-SNAPSHOT'
 nav:
   - modules/ROOT/nav.adoc

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -3,7 +3,6 @@
 * xref:about:terminology.adoc[Terminology]
 
 .Installation
-* xref:installation:requirements.adoc[Requirements]
 * xref:installation:installation.adoc[Installation]
 
 .Configuration
@@ -18,5 +17,5 @@
 
 .Reference
 * xref:reference:config-properties.adoc[Config Properties]
-* xref:reference:endpoints.adoc[ReST Endpoints]
+* xref:reference:endpoints.adoc[REST Endpoints]
 * xref:reference:shell-commands.adoc[Useful Karaf Shell Commands]

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,6 +1,14 @@
-= User's Guide to the _OpenNMS Velocloud Plugin_
+= User's Guide to the OpenNMS Velocloud Plugin
 :imagesdir: ../assets/images
 :!sectids:
+
+:description: Learn about the OpenNMS Velocloud plugin, which lets you monitor the status and collect events and performance metrics of Velocloud entities.
+
+[options="autowidth"]
+|===
+|Version:     |{full-display-version}
+|Last update: |{docdatetime}
+|===
 
 VMware Velocloud is a software-defined WAN solution for deploying enterprise-wide access to applications over private or public networks.
 

--- a/docs/modules/about/pages/introduction.adoc
+++ b/docs/modules/about/pages/introduction.adoc
@@ -1,6 +1,8 @@
 = Introduction
 :imagesdir: ../assets/images
 
+:description: Read a brief overview of the OpenNMS Velocloud plugin, which lets you monitor the status and collect events and performance metrics of Velocloud entities.
+
 The OpenNMS Velocloud Plugin lets you monitor the status and collect events and performance metrics of Velocloud entities.
 
 After installing the plugin, you must use the Orchestrator URLs and associated API keys to add connections.

--- a/docs/modules/about/pages/terminology.adoc
+++ b/docs/modules/about/pages/terminology.adoc
@@ -1,16 +1,18 @@
 = Terminology
 :imagesdir: ../assets/images
 
+:description: Learn some terms used with the OpenNMS Velocloud plugin, which lets you monitor the status and collect events and performance metrics of Velocloud entities.
+
 This section introduces some of the basic terms we use in this documentation.
 
 Partner:: A business entity that resells Velocloud as a solution.
 
 Customer:: A client of a partner.
 
-Orchestrator:: The Velocloud's SD-WAN controller, that hosts REST APIs, including endpoints to retrieve inventory, events, fault data, and performance data. 
+Orchestrator:: The Velocloud's SD-WAN controller, that hosts REST APIs, including endpoints to retrieve inventory, events, fault data, and performance data.
 It is used to manage gateways, edges, and links.
 
-Gateway:: The key components of the Velocloud multi-tenant, scalable, and redundant network that are deployed in cloud data centers around the world. 
+Gateway:: The key components of the Velocloud multi-tenant, scalable, and redundant network that are deployed in cloud data centers around the world.
 These network devices periodically send heartbeat packets and performance metrics to the Orchestrator.
 
 Edge:: A branded physical device that provides secure connectivity to private, public, or hybrid applications for a branch site.

--- a/docs/modules/configuration/pages/connections.adoc
+++ b/docs/modules/configuration/pages/connections.adoc
@@ -1,9 +1,11 @@
 = Connections
 :imagesdir: ../assets/images
 
-First, we have to define the connections the plugin uses to connect to the Orchestrator. A connection consists of
-an orchestrator URL, an API key to authenticate against the orchestrator, and an alias used to reference it. Connections
-are saved internally in the Secure Credentials Vault.
+:description: Learn how to define connections to the orchestrator in OpenNMS Velocloud plugin, to monitor and collect events and performance metrics of Velocloud entities.
+
+First, we have to define the connections the plugin uses to connect to the orchestrator.
+A connection consists of an orchestrator URL, an API key to authenticate against the orchestrator, and an alias used to reference it.
+Connections are saved internally in the Secure Credentials Vault.
 
 You can use REST endpoints and Karaf shell commands to add, validate, and modify connections.
 
@@ -32,7 +34,7 @@ The plugin mounts all endpoints at the following location: `http://localhost:898
 | Description
 | Query Options
 | `/connections`
-| Validates the incoming credentials and saves the valid connection to SCV. 
+| Validates the incoming credentials and saves the valid connection to SCV.
 Input requires `alias`, `orchestratorUrl`, and `apiKey` in JSON format.
 | *dryrun* - Do not save the connection.
 

--- a/docs/modules/configuration/pages/requisitions.adoc
+++ b/docs/modules/configuration/pages/requisitions.adoc
@@ -1,13 +1,16 @@
 = Requisitions
 :imagesdir: ../assets/images
 
+:description: Learn how to create a requisition to import Velocloud gateways, edges, and links into OpenNMS Horizon/Meridian through the Velocloud plugin.
+
 In order to monitor the Velocloud gateways, edges, and links, you need to import these entities into OpenNMS.
 To do so, create a requisition for a given connection alias.
+
 A connection alias can represent a customer connection or a partner connection.
-While a customer connection only allows you to query for entities associated with the customer itself, a partner connection has access to top-level entities that are shared by customers.
+While a customer connection only allows you to query for entities associated with the customer itself, a partner connection has access to top-level entities that customers share.
 All nodes created by a requisition are assigned to the same location controlled by the `location' parameter, which uses the default location if not specified.
 
-Furthermore, a partner connection can also be used to import customer entities by providing the customer's `enterpriseId` as an additional parameter.
+Furthermore, you can also use a partner connection to import customer entities by providing the customer's `enterpriseId` as an additional parameter.
 
 Specify the requisition type `velocloud-customer` to import all entities of a customer connection:
 
@@ -21,7 +24,7 @@ Specify the requisition type `velocloud-partner` to import all entities of a par
 opennms:import-requisition velocloud-partner alias=aPartnerAlias location=utopia
 ```
 
-A customer requisition can be created using a partner connection alias by providing the `enterpriseId` as an additional parameter.
+Use a partner connection alias to create a customer requisition by providing the `enterpriseId` as an additional parameter.
 The following example demonstrates the creation of a customer requisition by using a partner alias and an additional ´enterpriseId` parameter with the value set to `123`.
 
 ```

--- a/docs/modules/installation/pages/installation.adoc
+++ b/docs/modules/installation/pages/installation.adoc
@@ -1,7 +1,12 @@
 = Installation
 :imagesdir: ../assets/images
 
-## Deployment via KAR file
+:description: Learn how to install the OpenNMS Velocloud plugin, which lets you monitor the status and collect events and performance metrics of Velocloud entities.
+
+== Requirements
+The OpenNMS Velocloud Plugin can be used only with OpenNMS Horizon 31+ or OpenNMS Meridian 2023+.
+
+== Deployment via KAR file
 
 The installation of the plugin is simple.
 Just copy the provided KAR file to your OpenNMS `deploy` directory.
@@ -19,9 +24,9 @@ admin@opennms()> feature:install opennms-plugins-velocloud
 
 After installation, Velocloud-specific Karaf commands are available to configure the plugin.
 
-## Deploy from source
+== Deploy from source
 
-After checking out the repository, you can build and install the plugin into your local Maven repository using:
+After checking out the repository, you can build and install the plugin into your local Maven repository using the following:
 
 ```
 $ mvn clean install

--- a/docs/modules/installation/pages/requirements.adoc
+++ b/docs/modules/installation/pages/requirements.adoc
@@ -1,4 +1,0 @@
-= Requirements
-:imagesdir: ../assets/images
-
-The OpenNMS Velocloud Plugin can only be used with OpenNMS Horizon 31+ or OpenNMS Meridian 2023+.

--- a/docs/modules/operation/pages/api-caching.adoc
+++ b/docs/modules/operation/pages/api-caching.adoc
@@ -1,7 +1,9 @@
 = API Caching
 :imagesdir: ../assets/images
 
+:description: Learn how to adjust the cache retention period in OpenNMS Velocloud plugin.
+
 Access to the Velocloud Orchestrator REST APIs is rate limited for its clients.
-In order to respect these rate limits, we use caching on API calls.
+To respect these rate limits, we use caching on API calls.
 
 The cache retention period can be altered by modifying the `cache.retention` configuration property.

--- a/docs/modules/operation/pages/data-collection.adoc
+++ b/docs/modules/operation/pages/data-collection.adoc
@@ -1,21 +1,23 @@
 = Data Collection
 :imagesdir: ../assets/images
 
+:description: Learn about the different collectors used to gather key metrics of Velocloud entities through the OpenNMS Velocloud plugin.
+
 Various collectors exist to gather key metrics of the Velocloud entities in OpenNMS:
 
-## Edges
+== Edges
 * CPU and Memory usage
 * Flows counter and Queue drops
 * Tunnel IPv4/IPv6 counter
 * Received/transmitted bytes and packets per Application
 
-## Links
-* Bandwidth, Latency and Jitter
+== Links
+* Bandwidth, Latency, and Jitter
 * Data loss (reception, transmission)
 * Link score (reception, transmission)
 * Traffic statistics for Priority Groups and Control Traffic
 
-## Gateways
+== Gateways
 * CPU and Memory usage
 * Flows counter and Handoff Queue Drops
 * Tunnel IPv4/IPv6 counter

--- a/docs/modules/operation/pages/event-polling.adoc
+++ b/docs/modules/operation/pages/event-polling.adoc
@@ -1,8 +1,11 @@
 = Events
 :imagesdir: ../assets/images
 
+:description: View the event definitions the OpenNMS Velocloud plugin uses to associate collected events and entities in Horizon/Meridian.
+
 After installation, the plugin starts to collect events for the configured connections.
 These events will be associated with the corresponding entities in the OpenNMS system, using the following event definitions:
+
 ```
 <events xmlns="http://xmlns.opennms.org/xsd/eventconf">
     <event>

--- a/docs/modules/operation/pages/service-assurance.adoc
+++ b/docs/modules/operation/pages/service-assurance.adoc
@@ -1,20 +1,22 @@
 = Service Assurance
 :imagesdir: ../assets/images
 
+:description: Learn about the service monitors bound to imported Velocloud entities in OpenNMS Horizon/Meridian through the Velocloud plugin.
+
 Various service monitors will be bound to the imported Velocloud entities in OpenNMS:
 
-## Edges
+== Edges
 * Edge Connection Status Poller
 * Edge Service Status Poller
 * Edge Management Status Poller
 * Edge Path Status Poller
 * Edge Data Center Services Poller
 
-## Links
+== Links
 * Link Connection Status Poller
 * Link Service Status Poller
 * Link Tunnel Status Poller
 
-## Gateways
+== Gateways
 * Gateway Connection Status Poller
 * Gateway Service Status Poller

--- a/docs/modules/reference/pages/config-properties.adoc
+++ b/docs/modules/reference/pages/config-properties.adoc
@@ -1,6 +1,8 @@
 = Configuration Properties
 :imagesdir: ../assets/images
 
+:description: Learn how to set the event polling interval and the retention period for API calls in the OpenNMS Velocloud plugin.
+
 Some configuration properties let you fine-tune the plugin's behavior:
 
 .Configuration protperties for `org.opennms.velocloud`

--- a/docs/modules/reference/pages/endpoints.adoc
+++ b/docs/modules/reference/pages/endpoints.adoc
@@ -1,7 +1,9 @@
 = REST Endpoints
 :imagesdir: ../assets/images
 
-Some RESTful endpoints are available for basic connection management.
+:description: Learn about the REST endpoints available for basic connection management in the OpenNMS Velocloud plugin.
+
+Some REST endpoints are available for basic connection management.
 
 NOTE: The `Content-Type` of the request and response is `application/json`.
 

--- a/docs/modules/reference/pages/shell-commands.adoc
+++ b/docs/modules/reference/pages/shell-commands.adoc
@@ -1,6 +1,8 @@
 = Useful Karaf Shell Commands
 :imagesdir: ../assets/images
 
+:description: View Karaf shell commands in the OpenNMS Velocloud plugin: add connections, list customers, and import requisition.
+
 == opennms-velocloud:connection-add
 
 Add a connection to a Velocloud Orchestrator.


### PR DESCRIPTION
DP-96: Add meta descriptions to each page in the Velocloud docs - added meta descriptions to each page for better SEO.

DP-83: Add doc information to each product landing page - added version and last update information to Velocloud plugin landing page.

Updated some content to align with style guides. 